### PR TITLE
Update resource mapping server extensibility

### DIFF
--- a/source/Server/Configuration/GuestConfigurationSettings.cs
+++ b/source/Server/Configuration/GuestConfigurationSettings.cs
@@ -11,8 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.Configuration
 
         public GuestConfigurationSettings(
             IGuestConfigurationStore guestConfigurationStore,
-            IGuestUserStateChecker guestUserStateChecker,
-            IResourceMappingFactory factory) : base(guestConfigurationStore, factory)
+            IGuestUserStateChecker guestUserStateChecker) : base(guestConfigurationStore)
         {
             this.guestUserStateChecker = guestUserStateChecker;
         }
@@ -28,16 +27,13 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.Configuration
             yield return new ConfigurationValue("Octopus.WebPortal.GuestLoginEnabled", ConfigurationDocumentStore.GetIsEnabled().ToString(), ConfigurationDocumentStore.GetIsEnabled(), "Is Enabled");
         }
 
-        public override IEnumerable<IResourceMapping> GetMappings()
+        public override void BuildMappings(IResourceMappingsBuilder builder)
         {
-            return new[]
-            {
-                ResourceMappingFactory.Create<GuestConfigurationResource, GuestConfiguration>()
-                    .EnrichModel((resource, model, context) =>
-                    {
-                        guestUserStateChecker.EnsureGuestUserIsInCorrectState(resource.IsEnabled);
-                    })
-            };
+            builder.Map<GuestConfigurationResource, GuestConfiguration>()
+                .EnrichModel((model, resource) =>
+                {
+                    guestUserStateChecker.EnsureGuestUserIsInCorrectState(resource.IsEnabled);
+                });
         }
     }
 }

--- a/source/Server/Configuration/GuestConfigurationStore.cs
+++ b/source/Server/Configuration/GuestConfigurationStore.cs
@@ -1,6 +1,5 @@
 ﻿using Octopus.Data.Storage.Configuration;
 using Octopus.Node.Extensibility.Extensions.Infrastructure.Configuration;
-using Octopus.Node.Extensibility.HostServices.Mapping;
 using Octopus.Server.Extensibility.Authentication.Guest.GuestAuth;
 
 namespace Octopus.Server.Extensibility.Authentication.Guest.Configuration
@@ -13,8 +12,7 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.Configuration
 
         public GuestConfigurationStore(
             IConfigurationStore configurationStore,
-            IGuestUserStateChecker guestUserStateChecker,
-            IResourceMappingFactory factory) : base(configurationStore, factory)
+            IGuestUserStateChecker guestUserStateChecker) : base(configurationStore)
         {
             this.guestUserStateChecker = guestUserStateChecker;
         }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="NuGet.Versioning" Version="3.4.3" />
     <PackageReference Include="Octopus.Configuration" Version="1.0.10" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.0.11" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
     <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="5.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.2-resourcemappingr0003" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="5.0.0" />
     <PackageReference Include="Octopus.Time" Version="1.0.8" />
   </ItemGroup>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -29,10 +29,10 @@
     <PackageReference Include="NuGet.Versioning" Version="3.4.3" />
     <PackageReference Include="Octopus.Configuration" Version="1.0.10" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.0.11" />
-    <PackageReference Include="Octopus.Node.Extensibility" Version="4.0.2-resourcemappingr0003" />
-    <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="5.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="4.0.2-resourcemappingr0003" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="5.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility" Version="5.0.0" />
+    <PackageReference Include="Octopus.Node.Extensibility.Authentication" Version="7.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="5.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="7.0.0" />
     <PackageReference Include="Octopus.Time" Version="1.0.8" />
   </ItemGroup>
 


### PR DESCRIPTION
The resource mapping part of `Octopus.Server.Extensibility` has changed. I'm updating this solution accordingly.