### PR TITLE
Guest account 'Kiosk mode'

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -53,7 +53,6 @@ Task("__Default")
     .IsDependentOn("__Restore")
     .IsDependentOn("__Build")
     .IsDependentOn("__Pack")
-    .IsDependentOn("__Publish")
     .IsDependentOn("__CopyToLocalPackages");
 
 Task("__Clean")
@@ -107,27 +106,6 @@ Task("__Pack")
         });
     });
 
-Task("__Publish")
-    .WithCriteria(BuildSystem.IsRunningOnTeamCity)
-    .Does(() =>
-{
-    NuGetPush($"{artifactsDir}/Octopus.Server.Extensibility.Authentication.Guest.{nugetVersion}.nupkg", new NuGetPushSettings {
-		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget",
-		ApiKey = EnvironmentVariable("FeedzIoApiKey")
-	});
-    NuGetPush($"{artifactsDir}/Octopus.Client.Extensibility.Authentication.Guest.{nugetVersion}.nupkg", new NuGetPushSettings {
-		Source = "https://f.feedz.io/octopus-deploy/dependencies/nuget",
-		ApiKey = EnvironmentVariable("FeedzIoApiKey")
-	});
-
-     if (gitVersionInfo.PreReleaseLabel == "")
-    {
-        NuGetPush($"{artifactsDir}/Octopus.Client.Extensibility.Authentication.Guest.{nugetVersion}.nupkg", new NuGetPushSettings {
-            Source = "https://www.nuget.org/api/v2/package",
-            ApiKey = EnvironmentVariable("NuGetApiKey")
-        });
-    }
-});
 
 Task("__CopyToLocalPackages")
     .WithCriteria(BuildSystem.IsLocalBuild)

--- a/source/Server/GuestAuth/GuestCredentialValidator.cs
+++ b/source/Server/GuestAuth/GuestCredentialValidator.cs
@@ -40,11 +40,11 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
             }
             else if (user == null)
             {
-                messageText = "Guest login is enabled, but the guest user acccount could not be found so the login request was rejected. Please restart the Octopus server.";
+                messageText = "Guest login is enabled, but the guest user account could not be found so the login request was rejected. Please restart the Octopus server.";
             }
             else if (user.IsActive == false)
             {
-                messageText = "Guest login is enabled, but the guest acccount is disabled so the login request was rejected. Please re-enable the guest account if you want guest logins to work.";
+                messageText = "Guest login is enabled, but the guest account is disabled so the login request was rejected. Please re-enable the guest account if you want guest logins to work.";
             }
 
             log.Warn(messageText);

--- a/source/Server/GuestExtension.cs
+++ b/source/Server/GuestExtension.cs
@@ -35,7 +35,7 @@ namespace Octopus.Server.Extensibility.Authentication.Guest
                 .As<IGuestCredentialValidator>()
                 .As<IDoesBasicAuthentication>()
                 .InstancePerDependency();
-
+            builder.RegisterType<GuestLoginParametersHandler>().As<ICanHandleLoginParameters>().InstancePerDependency();
             builder.RegisterType<GuestAuthenticationProvider>().As<IAuthenticationProvider>().InstancePerDependency();
         }
     }

--- a/source/Server/GuestLoginParametersHandler.cs
+++ b/source/Server/GuestLoginParametersHandler.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using Octopus.CoreUtilities;
+using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Authentication.Guest.Configuration;
+using Octopus.Server.Extensibility.Authentication.Web;
+
+namespace Octopus.Server.Extensibility.Authentication.Guest
+{
+    public class GuestLoginParametersHandler : ICanHandleLoginParameters
+    {
+        private readonly IGuestConfigurationStore guestConfigurationStore;
+        const string AutoLoginParameterName = "autologin";
+        const string AutoLoginParameterValue = "guest";
+        
+        public GuestLoginParametersHandler(IGuestConfigurationStore guestConfigurationStore)
+        {
+            this.guestConfigurationStore = guestConfigurationStore;
+        }
+        
+        public Maybe<LoginInitiatedResult> WasExternalLoginInitiated(string encodedQueryString)
+        {
+            if (!guestConfigurationStore.GetIsEnabled())
+                return Maybe<LoginInitiatedResult>.None;
+            var parser = new EncodedQueryStringParser();
+            var parameters = parser.Parse(encodedQueryString);
+            
+            var autoLoginParameter = GetAutoLoginParameterIfPresent(parameters);
+            
+            return autoLoginParameter.SelectValueOr(
+                selector: LoginAsGuest,
+                ifNone: Maybe<LoginInitiatedResult>.None);
+        }
+
+        private static Maybe<LoginInitiatedResult> LoginAsGuest(EncodedQueryStringParser.QueryStringParameter arg)
+        {
+            return new LoginInitiatedResult(GuestAuthenticationProvider.ProviderName).AsSome();
+        }
+
+        private static Maybe<EncodedQueryStringParser.QueryStringParameter> GetAutoLoginParameterIfPresent(EncodedQueryStringParser.QueryStringParameter[] parameters)
+        {
+            return parameters.FirstOrDefault(p =>
+                p.Name.Equals(AutoLoginParameterName, StringComparison.OrdinalIgnoreCase) &&
+                p.Value.Equals(AutoLoginParameterValue, StringComparison.OrdinalIgnoreCase)).ToMaybe();
+        }
+    }
+}


### PR DESCRIPTION
We used to have a 'kiosk' feature that allowed for automatically logging into a guest account.

This is PR brings that feature back :tada: 

I'm hoping that the reviewer can ensure I've covered of any edge cases, as I'm pretty new in this corner of the code base.

Related changes:
- [PR in Octopus Server - private repo](https://github.com/OctopusDeploy/OctopusDeploy/pull/3809)
- [Docs PR](https://github.com/OctopusDeploy/docs/pull/391)

[Internal tracking](https://trello.com/c/fRwz4kXc/146-allow-guest-autologin-via-query-string-parameters)