### PR TITLE
Enabling Nullable Reference Types

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -20,7 +20,7 @@ var publishDir = "./publish";
 var localPackagesDir = "../LocalPackages";
 var artifactsDir = "./artifacts";
 var assetDir = "./BuildAssets";
-var bin = "/bin/Release/netstandard2.0/";
+var bin = "/bin/Release/netstandard2.1/";
 
 var gitVersionInfo = GitVersion(new GitVersionSettings {
     OutputType = GitVersionOutput.Json

--- a/source/GuestAuthenticationProvider.sln.DotSettings
+++ b/source/GuestAuthenticationProvider.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>

--- a/source/Server/GuestAuth/GuestCredentialValidator.cs
+++ b/source/Server/GuestAuth/GuestCredentialValidator.cs
@@ -24,6 +24,8 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
             this.configurationStore = configurationStore;
         }
 
+        public string IdentityProviderName => GuestAuthenticationProvider.ProviderName;
+
         public int Priority => 1;
 
         public ResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)

--- a/source/Server/GuestAuth/GuestCredentialValidator.cs
+++ b/source/Server/GuestAuth/GuestCredentialValidator.cs
@@ -28,7 +28,7 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
 
         public int Priority => 1;
 
-        public ResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
+        public IResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
         {
             if ((!configurationStore.GetIsEnabled() || !string.Equals(username, User.GuestLogin, StringComparison.OrdinalIgnoreCase)))
                 return ResultFromExtension<IUser>.ExtensionDisabled();

--- a/source/Server/GuestAuth/GuestCredentialValidator.cs
+++ b/source/Server/GuestAuth/GuestCredentialValidator.cs
@@ -4,7 +4,7 @@ using Octopus.Data.Model.User;
 using Octopus.Data.Storage.User;
 using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.Guest.Configuration;
-using Octopus.Server.Extensibility.Authentication.Storage.User;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
 {
@@ -26,17 +26,17 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
 
         public int Priority => 1;
 
-        public AuthenticationUserCreateResult ValidateCredentials(string username, string password, CancellationToken cancellationToken)
+        public ResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
         {
             if ((!configurationStore.GetIsEnabled() || !string.Equals(username, User.GuestLogin, StringComparison.OrdinalIgnoreCase)))
-                return new AuthenticationUserCreateResult();
+                return ResultFromExtension<IUser>.ExtensionDisabled();
 
             var user = userStore.GetByUsername(username);
             var messageText = "Error retrieving Guest user details";
 
             if (user != null && user.IsActive)
             {
-                return new AuthenticationUserCreateResult(user);
+                return ResultFromExtension<IUser>.Success(user);
             }
             else if (user == null)
             {
@@ -48,7 +48,7 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
             }
 
             log.Warn(messageText);
-            return new AuthenticationUserCreateResult(messageText);
+            return ResultFromExtension<IUser>.Failed(messageText);
         }
     }
 }

--- a/source/Server/GuestAuth/GuestUserStateChecker.cs
+++ b/source/Server/GuestAuth/GuestUserStateChecker.cs
@@ -29,16 +29,16 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
                 var userResult = userStore.Create(
                     User.GuestLogin,
                     "Guest",
-                    null,
+                    string.Empty,
                     CancellationToken.None,
                     apiKeyDescriptor: new ApiKeyDescriptor("API-GUEST", "API-GUEST"),
                     password: Guid.NewGuid().ToString());
-                if (!userResult.Succeeded)
+                if (userResult.WasFailure)
                 {
-                    log.Error("Error creating guest account: " + userResult.FailureReason);
+                    log.Error("Error creating guest account: " + userResult.ErrorString);
                     return;
                 }
-                user = userResult.User;
+                user = userResult.Value;
 
                 // When the special guest login mode is enabled, no password is actually needed for the guest. 
                 // But we give them a default password anyway just in case someone disables guest login and then re-enables the 
@@ -48,8 +48,8 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
                 user.SetPassword(pwd);
             }
 
-            // if we're enabling then by now the user must exist
-            if (isEnabled)
+            // if we're enabling then by now the user must exist (we're doing the null check here to keep the compiler happy)
+            if (user != null && isEnabled)
             {
                 userStore.EnableUser(user.Id);
             }

--- a/source/Server/GuestAuth/GuestUserStateChecker.cs
+++ b/source/Server/GuestAuth/GuestUserStateChecker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Octopus.Data;
 using Octopus.Data.Model.User;
 using Octopus.Data.Storage.User;
 using Octopus.Diagnostics;
@@ -33,12 +34,13 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
                     CancellationToken.None,
                     apiKeyDescriptor: new ApiKeyDescriptor("API-GUEST", "API-GUEST"),
                     password: Guid.NewGuid().ToString());
-                if (userResult.WasFailure)
+                if (userResult is FailureResult failure)
                 {
-                    log.Error("Error creating guest account: " + userResult.ErrorString);
+                    log.Error("Error creating guest account: " + failure.ErrorString);
                     return;
                 }
-                user = userResult.Value!; // this cannot actually be null if we got a result back
+
+                user = ((Result<IUser>)userResult).Value;
 
                 // When the special guest login mode is enabled, no password is actually needed for the guest.
                 // But we give them a default password anyway just in case someone disables guest login and then re-enables the

--- a/source/Server/GuestAuth/GuestUserStateChecker.cs
+++ b/source/Server/GuestAuth/GuestUserStateChecker.cs
@@ -38,10 +38,10 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.GuestAuth
                     log.Error("Error creating guest account: " + userResult.ErrorString);
                     return;
                 }
-                user = userResult.Value;
+                user = userResult.Value!; // this cannot actually be null if we got a result back
 
-                // When the special guest login mode is enabled, no password is actually needed for the guest. 
-                // But we give them a default password anyway just in case someone disables guest login and then re-enables the 
+                // When the special guest login mode is enabled, no password is actually needed for the guest.
+                // But we give them a default password anyway just in case someone disables guest login and then re-enables the
                 // account
                 var randomMilliseconds = new Random(DateTimeOffset.UtcNow.Millisecond).Next(100000);
                 var pwd = DateTimeOffset.UtcNow.AddMilliseconds(randomMilliseconds).ToString();

--- a/source/Server/GuestLoginParametersHandler.cs
+++ b/source/Server/GuestLoginParametersHandler.cs
@@ -16,8 +16,10 @@ namespace Octopus.Server.Extensibility.Authentication.Guest
         {
             this.guestConfigurationStore = guestConfigurationStore;
         }
-        
-        public LoginInitiatedResult? WasExternalLoginInitiated(string encodedQueryString)
+
+        public string IdentityProviderName => GuestAuthenticationProvider.ProviderName;
+
+        public bool? WasExternalLoginInitiated(string encodedQueryString)
         {
             if (!guestConfigurationStore.GetIsEnabled())
                 return null;
@@ -25,12 +27,7 @@ namespace Octopus.Server.Extensibility.Authentication.Guest
             var parameters = parser.Parse(encodedQueryString);
             
             var autoLoginParameter = GetAutoLoginParameterIfPresent(parameters);
-            return autoLoginParameter != null ? LoginAsGuest(autoLoginParameter) : null;
-        }
-
-        private static LoginInitiatedResult LoginAsGuest(EncodedQueryStringParser.QueryStringParameter arg)
-        {
-            return new LoginInitiatedResult(GuestAuthenticationProvider.ProviderName);
+            return autoLoginParameter != null;
         }
 
         private static EncodedQueryStringParser.QueryStringParameter? GetAutoLoginParameterIfPresent(EncodedQueryStringParser.QueryStringParameter[] parameters)

--- a/source/Server/GuestLoginParametersHandler.cs
+++ b/source/Server/GuestLoginParametersHandler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Octopus.CoreUtilities;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.Guest.Configuration;
 using Octopus.Server.Extensibility.Authentication.Web;
@@ -18,30 +17,27 @@ namespace Octopus.Server.Extensibility.Authentication.Guest
             this.guestConfigurationStore = guestConfigurationStore;
         }
         
-        public Maybe<LoginInitiatedResult> WasExternalLoginInitiated(string encodedQueryString)
+        public LoginInitiatedResult? WasExternalLoginInitiated(string encodedQueryString)
         {
             if (!guestConfigurationStore.GetIsEnabled())
-                return Maybe<LoginInitiatedResult>.None;
+                return null;
             var parser = new EncodedQueryStringParser();
             var parameters = parser.Parse(encodedQueryString);
             
             var autoLoginParameter = GetAutoLoginParameterIfPresent(parameters);
-            
-            return autoLoginParameter.SelectValueOr(
-                selector: LoginAsGuest,
-                ifNone: Maybe<LoginInitiatedResult>.None);
+            return autoLoginParameter != null ? LoginAsGuest(autoLoginParameter) : null;
         }
 
-        private static Maybe<LoginInitiatedResult> LoginAsGuest(EncodedQueryStringParser.QueryStringParameter arg)
+        private static LoginInitiatedResult LoginAsGuest(EncodedQueryStringParser.QueryStringParameter arg)
         {
-            return new LoginInitiatedResult(GuestAuthenticationProvider.ProviderName).AsSome();
+            return new LoginInitiatedResult(GuestAuthenticationProvider.ProviderName);
         }
 
-        private static Maybe<EncodedQueryStringParser.QueryStringParameter> GetAutoLoginParameterIfPresent(EncodedQueryStringParser.QueryStringParameter[] parameters)
+        private static EncodedQueryStringParser.QueryStringParameter? GetAutoLoginParameterIfPresent(EncodedQueryStringParser.QueryStringParameter[] parameters)
         {
             return parameters.FirstOrDefault(p =>
                 p.Name.Equals(AutoLoginParameterName, StringComparison.OrdinalIgnoreCase) &&
-                p.Value.Equals(AutoLoginParameterValue, StringComparison.OrdinalIgnoreCase)).ToMaybe();
+                p.Value.Equals(AutoLoginParameterValue, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -10,13 +10,14 @@
     <PackageProjectUrl>https://github.com/OctopusDeploy/GuestAuthenticationProvider</PackageProjectUrl>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.0.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Configuration" Version="2.0.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.1" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.0" />
   </ItemGroup>
 

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Octopus.Configuration" Version="2.0.2-enh-nullable0003" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.1" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -4,18 +4,19 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.Guest</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.Guest</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Octopus Deploy</Authors>
     <PackageLicenseUrl>https://github.com/OctopusDeploy/GuestAuthenticationProvider/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/OctopusDeploy/GuestAuthenticationProvider</PackageProjectUrl>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.0" />
+    <PackageReference Include="Octopus.Configuration" Version="2.0.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changing the method return types to align with the new nullable patterns we've set up in ServerExtensibility and AuthenticationExtensibility.

Depends on:
OctopusDeploy/AuthenticationExtensibility#15