### PR TITLE
Add OnConfigurationChange override to GuestConfigurationStore

### DIFF
--- a/source/Server/Configuration/GuestConfigurationStore.cs
+++ b/source/Server/Configuration/GuestConfigurationStore.cs
@@ -24,5 +24,11 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.Configuration
             base.SetIsEnabled(isEnabled);
             guestUserStateChecker.EnsureGuestUserIsInCorrectState(isEnabled);
         }
+
+        protected override void OnConfigurationChanged()
+        {
+            base.OnConfigurationChanged();
+            guestUserStateChecker.EnsureGuestUserIsInCorrectState(GetIsEnabled());
+        }
     }
 }


### PR DESCRIPTION
Adds the following override to the GuestConfigurationStore to ensure that the GuestUser is created when enabling the GuestUserLogin feature via the API:

```
        protected override void OnConfigurationChanged()
        {
            base.OnConfigurationChanged();
            guestUserStateChecker.EnsureGuestUserIsInCorrectState(GetIsEnabled());
        }
```

Without this, the E2E GuestUserTestScript test will fail since we are now enabling this behaviour in the test via the API (instead of the Command Line). The commandline calls a different override (SetIsEnabled) which will call the `guestUserStateChecker.EnsureGuestUserIsInCorrectState(isEnabled);` method to create the guest user.

