### PR TITLE
restore deleted method

### DIFF
--- a/source/Server/Configuration/GuestConfigurationStore.cs
+++ b/source/Server/Configuration/GuestConfigurationStore.cs
@@ -24,5 +24,11 @@ namespace Octopus.Server.Extensibility.Authentication.Guest.Configuration
             base.SetIsEnabled(isEnabled);
             guestUserStateChecker.EnsureGuestUserIsInCorrectState(isEnabled);
         }
+
+        protected override void OnConfigurationChanged()
+        {
+            base.OnConfigurationChanged();
+            guestUserStateChecker.EnsureGuestUserIsInCorrectState(GetIsEnabled());
+        }
     }
 }


### PR DESCRIPTION
A method was removed during build changes from cake to nuke - https://github.com/OctopusDeploy/GuestAuthenticationProvider/pull/19/files#diff-9f83eaaf92d390b51166017924197d948fac7707cf8a34fe73a93babaaed2b8bL27-L32

